### PR TITLE
Improve header text contrast

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2,7 +2,8 @@
 
 .tm-header {
     color: white;
-    background-image: url("/images/twittering_machine.jpg");
+    /* Darken the header image so text remains readable */
+    background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url("/images/twittering_machine.jpg");
     background-size: cover;
     padding: 4rem 1rem;
 }


### PR DESCRIPTION
## Summary
- darken the header background using a linear gradient for better text visibility

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683fea97106c83208b710761dc26bfaf